### PR TITLE
Fix improper docker compose dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,9 @@ services:
     container_name: sorasvl-router
     build:
       context: ./nginx
+    depends_on:
+      - server
+      - client
     ports:
       - "80:80"
     networks:
@@ -35,8 +38,6 @@ services:
   # MongoDB
   mongo:
     container_name: sorasvl-mongo
-    depends_on:
-      - nginx
     build:
       context: ./mongo
     ports:


### PR DESCRIPTION
- `mongo` does not need `server` to be up when they're starting

- `router` needs `server` and `client` to be up when they`re starting
```
# in nginx.conf
upstream v1 {
  server sorasvl-server:3000;
}

upstream client {
  server sorasvl-client:3000;
}
```

However, current dependency does not match for those conditions. This leads to us run `docker-compose up -d` command twice to start router.

So, this PR set dependency properly in `docker-compose.yml` to start containers smoothly.