### PR TITLE
Handle multiple simulators

### DIFF
--- a/client/src/pages/Simulations.tsx
+++ b/client/src/pages/Simulations.tsx
@@ -1,39 +1,68 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Layout from "../components/Layout";
+import { SimulatorStatusMap } from "../utils/types";
 
 function Simulations() {
-  const onStopSimulation = () => {
-    fetch(`/api/v1/clusters/stop`);
+  const onStopSimulation = (simulatorId: string) => {
+    fetch(`/api/v1/clusters/stop/${simulatorId}`);
   };
-  const onDisconnectSimulator = () => {
-    fetch(`/api/v1/clusters/disconnect`);
+  const onDisconnectSimulator = (simulatorId: string) => {
+    fetch(`/api/v1/clusters/disconnect/${simulatorId}`);
   };
-  const onStartSimulation = () => {
-    fetch(`/api/v1/clusters/start/apiOnly`);
+  const onStartSimulation = (simulatorId: string) => {
+    fetch(`/api/v1/clusters/start/apiOnly/${simulatorId}`);
   };
+
+  const [simulatorStatus, setSimulatorStatus] = useState<SimulatorStatusMap>({});
+
+  useEffect(() => {
+    const fetchSimulatorStatus = async () => {
+      const res = await fetch(
+        `/api/v1/clusters/simulatorStatus`
+      );
+      const simulatorStatus = await res.json();
+      setSimulatorStatus(simulatorStatus as SimulatorStatusMap);
+    };
+
+    const updateSimulatorStatus = setInterval(() => {
+      fetchSimulatorStatus();
+    }, 500);
+
+    return () => { clearInterval(updateSimulatorStatus) };
+  }, []);
 
   return (
     <Layout>
-      <div className="w-full h-full p-8 space-y-4 space-x-4">
-        <a
-          className="bg-blue-500 hover:bg-blue-800 cursor-pointer px-4 py-2 text-white rounded"
-          onClick={onStartSimulation}
-        >
-          API Only
-        </a>
-        <a
-          className="bg-blue-500 hover:bg-blue-800 cursor-pointer px-4 py-2 text-white rounded"
-          onClick={onStopSimulation}
-        >
-          Stop Simulation
-        </a>
-        <a
-          className="bg-blue-500 hover:bg-blue-800 cursor-pointer px-4 py-2 text-white rounded"
-          onClick={onDisconnectSimulator}
-        >
-          Disconnect
-        </a>
-      </div>
+      {Object.keys(simulatorStatus).map(simulatorId => {
+        const { alive, running } = simulatorStatus[simulatorId];
+        return (
+          <div className="w-full p-8 space-y-4 space-x-4">
+            <div className="grid gap-4 grid-cols-4 pv-4 text-center">
+            <span className="col-span-2 align-middle font-bold text-lg">
+              {simulatorId}
+            </span>
+            <span className={`${alive ? "bg-green-400" : "bg-red-400"} font-bold text-white`}>
+              {alive ? "Online" : "Offline"}
+            </span>
+            <span className={`${running ? "bg-green-400" : "bg-red-400"} font-bold text-white`}>
+              {running ? "Running" : "Stopped"}
+            </span>
+            <a
+              className="col-span-2 bg-blue-500 hover:bg-blue-800 cursor-pointer px-4 py-2 text-white rounded"
+              onClick={() => running ? onStopSimulation(simulatorId) : onStartSimulation(simulatorId)}
+            >
+              {simulatorStatus[simulatorId].running ? "Stop Simulation" : "API Only"}
+            </a>
+            <a
+              className="col-span-2 bg-blue-500 hover:bg-blue-800 cursor-pointer px-4 py-2 text-white rounded"
+              onClick={() => onDisconnectSimulator(simulatorId)}
+            >
+              Disconnect
+            </a>
+            </div>
+          </div>
+        );
+      })}
     </Layout>
   );
 }

--- a/client/src/pages/Simulations.tsx
+++ b/client/src/pages/Simulations.tsx
@@ -24,6 +24,7 @@ function Simulations() {
       setSimulatorStatus(simulatorStatus as SimulatorStatusMap);
     };
 
+    fetchSimulatorStatus();
     const updateSimulatorStatus = setInterval(() => {
       fetchSimulatorStatus();
     }, 500);

--- a/client/src/utils/types.tsx
+++ b/client/src/utils/types.tsx
@@ -46,3 +46,12 @@ export type Plugin = {
   };
   category: string;
 };
+
+export type SimulatorStatusMap = {
+  [simulatorId: string]: SimulatorStatus;
+}
+
+export type SimulatorStatus = {
+  alive: boolean;
+  running: boolean;
+};

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -15,6 +15,7 @@ connectToDatabase()
   .then(() => {
     app.use(bodyParser.urlencoded({ extended: true }));
     app.use(cors());
+    app.use(express.json());
     app.use("/api/v1/clusters", clustersRouter);
     app.use("/api/v1/assets/download", assetsRouter);
     app.use("/api/v1", apiRouter);

--- a/server/src/routers/clusters.router.ts
+++ b/server/src/routers/clusters.router.ts
@@ -3,40 +3,53 @@ import events from "events";
 import apiOnly from "../templates/apiOnly";
 
 export const clustersRouter = express.Router();
+interface SimulatorStatus {
+  alive: boolean;
+  running: boolean;
+}
 
 clustersRouter.use(express.json());
 
 const clusterEmitter = new events.EventEmitter();
+const simulatorStatus: {[SimulatorId: string]: SimulatorStatus} = {};
 
 function registerClientEventHandlers(
   req: express.Request,
   res: express.Response
 ) {
+  const simId = req.headers['simid'] as string;
+  simulatorStatus[simId] = { alive: true, running: false };
+
   // connection established
   res.write(`data:{status:'OK'}\n\n`);
 
-  clusterEmitter.on("CONFIG", (template) => {
+  clusterEmitter.on(`CONFIG-${simId}`, (template) => {
     res.write(`data:{"status":"Config", "data":${template}}\n\n`);
+    simulatorStatus[simId].running = true;
   });
 
   // stop simulation
-  clusterEmitter.on("STOP", () => {
+  clusterEmitter.on(`STOP-${simId}`, () => {
     res.write("data:{'status':'Stop'}\n\n");
+    simulatorStatus[simId].running = false;
   });
 
   // disconnect client
-  clusterEmitter.on("DISCONNECT", () => {
+  clusterEmitter.on(`DISCONNECT-${simId}`, () => {
     res.write("data:{'status':'Disconnect'}\n\n");
+    simulatorStatus[simId].alive = false;
   });
 
   // server notified when client closes connection
   res.on('close', () => {
-    console.log('<- client disconnected')
+    console.log(`<- client ${simId} disconnected`)
+    simulatorStatus[simId] = { alive: false, running: false };
   });
 }
 
 clustersRouter.post("/connect", (req, res) => {
-  console.log("-> client connected");
+  const simId = req.headers['simid'];
+  console.log(`-> client ${simId} connected`);
   // set up SSE connection
   res.writeHead(200, {
     "Content-Type": "text/event-stream",
@@ -48,23 +61,34 @@ clustersRouter.post("/connect", (req, res) => {
   registerClientEventHandlers(req, res);
 });
 
-clustersRouter.get("/start/apiOnly", (req, res) => {
+clustersRouter.get("/simulatorStatus", (req, res) => {
   console.log(req.path);
+  // return simulator status
+  res.status(200).json(simulatorStatus);
+});
+
+clustersRouter.get("/start/apiOnly/:simId", (req, res) => {
+  console.log(req.path);
+  const simId = req.params.simId;
   // start an API ONLY simulation
-  clusterEmitter.emit("CONFIG", JSON.stringify(apiOnly));
+  if (simulatorStatus[simId].alive) {
+    clusterEmitter.emit(`CONFIG-${simId}`, JSON.stringify(apiOnly));
+  }
   res.status(200).send("OK");
 });
 
-clustersRouter.get("/stop", (req, res) => {
+clustersRouter.get("/stop/:simId", (req, res) => {
   console.log(req.path);
+  const simId = req.params.simId;
   // stop the current simulation
-  clusterEmitter.emit("STOP");
+  clusterEmitter.emit(`STOP-${simId}`);
   res.status(200).send("OK");
 });
 
-clustersRouter.get("/disconnect", (req, res) => {
+clustersRouter.get("/disconnect/:simId", (req, res) => {
   console.log(req.path);
+  const simId = req.params.simId;
   // disconnect the cluster
-  clusterEmitter.emit("DISCONNECT");
+  clusterEmitter.emit(`DISCONNECT-${simId}`);
   res.status(200).send("OK");
 });


### PR DESCRIPTION
This PR makes SORA-SVL server handle multiple simulators.
Users can interact each simulator in simulator page.

Server handles requests by simulator-specific event-listeners, and client fetches simulator status by every 500ms.

## Known Issue
### Status <> Actual Staus mismatching
Since server just marks running/alive after res write, ***there's chance that status and actual simulator status is not matching.*** (ex. after click API Only, even if Simulator is not on API only mode by some reason, server will set simulator status as running)

Currently, if such state has occurred, we can just stop & re-enter API mode to fix this

### Status handling
If user stops simulation on client, it reflects well on simulator. However, if user stops simulation on simulator manually or stopped on script, server status does not updated properly.


## Screenshots
![2022-08-19-01:02:58-screenshot](https://user-images.githubusercontent.com/18724352/185441964-580df4be-8f4b-4842-a94a-50ee8510a5c6.png)

![2022-08-19-01:08:11-screenshot](https://user-images.githubusercontent.com/18724352/185442841-420ad7ce-9111-4324-9ac7-47b7b69f2183.png)

